### PR TITLE
Fix user parameter for Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class memcached::params {
       $dev_package_name  = 'libmemcached-dev'
       $config_file       = '/etc/memcached.conf'
       $config_tmpl       = "${module_name}/memcached.conf.erb"
-      $user              = 'nobody'
+      $user              = 'memcache'
       $logfile           = '/var/log/memcached.log'
       $use_registry      = false
       $use_svcprop       = false


### PR DESCRIPTION
In Debian 10 and later, the `memcached` package installs a dedicated system account for memcached, named `memcache`. This makes the default module parameters align with the default.

Currently, when an `memcached::instance` is used, systemd complains with:

> systemd[1]: /etc/systemd/system/memcached@.service:21: Special user nobody configured, this is not safe!